### PR TITLE
Bugfix for display areas that are grouped in modal

### DIFF
--- a/modal/areas_modal.php
+++ b/modal/areas_modal.php
@@ -30,7 +30,7 @@ $collapsedState = 'collapsed';
 // Show no accordions when there is only one list of areas (likely a user with no grouping)
 if(count(array_keys($areas)) === 1){
     $collapsedState = '';
-    $areaList = $areas[""];
+    $areaList = $areas[array_keys($areas)[0]];
     echo "<ul>\n";
     sort($areaList);
     foreach ($areaList as $i => $area) {


### PR DESCRIPTION
This is a fix for a bug found when attempting to add new areas, that area grouped in poracle, to a "human".