### PR TITLE
Fixor Add Quest Pokemon Forms

### DIFF
--- a/actions/quests.php
+++ b/actions/quests.php
@@ -103,7 +103,7 @@
         $arr = explode("_", $mon_id);
         $mon_id = $arr[0];
 	$form_id = $arr[1];
-	if ( !isset($form_id) || $form_id = "" ) { $form_id = 0;}
+	if ( !isset($form_id) || $form_id == "" ) { $form_id = 0;}
 
         $stmt = $conn->prepare("INSERT INTO quest ( id, ping, clean, reward, template, shiny, reward_type, distance, profile_no, form)
                                VALUES ( ?, ?, ? , ?, ?, 0, 7, ?, ?, ?)");


### PR DESCRIPTION
Fixed the if statement to check if $form_id was set or "". $form_id = "" sets the variable to blank string. This should fix. double equals always so sneaky. :)