### PR TITLE
Add the option to synchronize webhooks

### DIFF
--- a/actions/channel_sync.php
+++ b/actions/channel_sync.php
@@ -11,6 +11,7 @@ if (isset($_POST['sync'])) {
 	      $target_fields = explode("|", $target);
 	      $target_db=$target_fields[0];
 	      $target_id=$target_fields[1];
+	      $target_id=str_replace("_com", ".com", $target_id);
 
               // Delete All Previous Trackings
 	      $stmt = $conn->prepare("DELETE FROM ".$target_db.".monsters WHERE id = ?");

--- a/admin_sync.php
+++ b/admin_sync.php
@@ -188,6 +188,56 @@ foreach ($dbnames as &$db) {
 
                     <?php } ?>
 
+                    <!-- Webhooks -->
+
+                    <?php
+
+                    $dbnames = explode(",", $dbname);
+                    foreach ($dbnames as &$db) {
+
+                       $conn = new mysqli($dbhost.":".$dbport, $dbuser, $dbpass, $db);
+                       $sql = "select id, name, type FROM humans WHERE type like 'webhook' AND id <> '".$_SESSION['id']."' ORDER by name";
+                       $result = $conn->query($sql);
+                       ?>
+
+                    <?php if ($result->num_rows <> 0) { ?>
+
+                    <hr>
+
+                    <!-- Heading -->
+                    <div class="row">
+                        <div class="col">
+                            <div class="alert alert-secondary text-center" role="alert">
+                                <?php if ($num_dbs > 1) { echo $db."<br>"; } ?>
+                                <strong><?php echo i8ln("WEBHOOKS TO SYNC WITH"); ?></strong>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div id='discord' class='areasform text-uppercase text-center'>
+
+                        <ul>
+                        <?php while ($row = $result->fetch_assoc()) {
+                           $target_id=$db."|".$row['id'];
+                        ?>
+
+                        <li class="btn btn-secondary btn-icon-split mr-2 mt-1">
+                            <span class="icon text-white-50">
+                                <input type='checkbox' name='target_<?php echo $target_id; ?>' id='target_<?php echo $target_id; ?>'>
+                                <label for='target_<?php echo $target_id; ?>'><font size="1">WH</font></label>
+                            </span>
+                            <span class="text" style="width:250px;"><?php echo $row['name']; ?></span>
+                        </li>
+
+                        <?php } ?>
+                        </ul>
+
+                    </div>
+
+                    <?php } ?>
+
+                    <?php } ?>
+
 		    <center><hr>
 		    <input class="btn" style="background-color:darkred; color:white;" type='submit' name='sync' id="sync" 
                            value='<?php echo i8ln("CONFIRM CHANNEL SYNCHRONIZATION"); ?>'>

--- a/admin_sync.php
+++ b/admin_sync.php
@@ -10,7 +10,7 @@ if (!isset($_SESSION['admin_id']) ) {
 
 # Page is only available if on a Channel
 
-if ( $_SESSION['type'] <> 'telegram:channel' && $_SESSION['type'] <> 'telegram:group' && $_SESSION['type'] <> 'discord:channel') {
+if ( $_SESSION['type'] <> 'telegram:channel' && $_SESSION['type'] <> 'telegram:group' && $_SESSION['type'] <> 'discord:channel' && $_SESSION['type'] <> 'webhook') {
         header("Location: $redirect_url");
         exit();
 }

--- a/header.php
+++ b/header.php
@@ -206,7 +206,7 @@ if (isset($_SESSION['admin_id']) && $_SESSION['admin_id'] <> $_SESSION['id'])
    $admin_alarm.="</div>";
    $admin_mode = "True";
 
-   if ($_SESSION['type'] == "discord:channel" || $_SESSION['type'] == "telegram:channel" || $_SESSION['type'] == "telegram:group" ) {
+   if ($_SESSION['type'] == "discord:channel" || $_SESSION['type'] == "telegram:channel" || $_SESSION['type'] == "telegram:group" || $_SESSION['type'] == "webhook" ) {
            $admin_alarm.="<a href='./admin_sync.php'>";
            $admin_alarm.="<button type='button' class='btn mb-2' style='width:100%; background-color:darkred; color:white;'>";
            $admin_alarm.=i8ln("Synchronize Other Channels with this one");


### PR DESCRIPTION
This works but I think the line I added to channel_sync.php is too dirty to be pushed to develop. 
In the POST request from admin_sync.php the webhook url dot gets changed to an underscore. I wrote a line to "fix" it: `$target_id=str_replace("_com", ".com", $target_id);`. I don't think it's the proper solution but I don't know enough php to fix it properly. 