### PR TITLE
Add a place holder for when there is no group

### DIFF
--- a/modal/areas_modal.php
+++ b/modal/areas_modal.php
@@ -56,13 +56,15 @@ if(count(array_keys($areas)) === 1){
     echo "<div class='accordion' id='accordion'>";
 
     foreach ($areas as $group => $areaList) {
+        // Check if $group is empty or null, and set the default text accordingly
+        $buttonText = !empty($group) ? $group : "No group";
         $updatedGroup = str_replace(' ', '_', $group);
 
         echo "<div class='card'>
              <div class='card-header' id='heading$updatedGroup'>
                   <h5 class='mb-0'>
                 <button class='btn btn-link $collapsedState' type='button' data-toggle='collapse' data-target='#collapse$updatedGroup' aria-expanded='false' aria-controls='collapse$updatedGroup'>
-                  $group
+                  $buttonText
                 </button>
               </h5>
             </div>


### PR DESCRIPTION
I had this behavior when selecting an area from the list:

![image](https://github.com/bbdoc/PoracleWeb/assets/2796788/b8017034-791a-4717-b670-b5df90c596be)

Note in the previous image that there are three fields, in which the first one has no string. For illustrative purposes: 

![image](https://github.com/bbdoc/PoracleWeb/assets/2796788/ba5b14d9-5b9f-4a21-9dbd-633c77ee66c6)

So I've added a default name to that category:

![image](https://github.com/bbdoc/PoracleWeb/assets/2796788/039524cc-3413-4d9a-bb27-e7c9c19f26fa)
