### PR TITLE
Fix sizes issue [ugly way]

### DIFF
--- a/modal/edit_pokemons_modal.php
+++ b/modal/edit_pokemons_modal.php
@@ -438,6 +438,7 @@ if ($row['pokemon_id'] == '0') {
                                 if ($row['size'] == 3 && $row['max_size'] == '3') { $checked3 = 'checked'; } else { $checked3 = ''; }
                                 if ($row['size'] == 4 && $row['max_size'] == '4') { $checked4 = 'checked'; } else { $checked4 = ''; }
                                 if ($row['size'] == 5 && $row['max_size'] == '5') { $checked5 = 'checked'; } else { $checked5 = ''; }
+                                if ($checked0 === '' && $checked1 === '' && $checked2 === '' && $checked3 === '' && $checked4 === '' && $checked5 === '') { $checked0 = 'checked'; }
                 ?>
                 <label class="btn btn-secondary">
                     <input type="radio" name="size" id="size_-1" value="size_-1" <?php echo $checked0; ?>> <?php echo i8ln("All"); ?>

--- a/modal/edit_pokemons_modal.php
+++ b/modal/edit_pokemons_modal.php
@@ -432,12 +432,12 @@ if ($row['pokemon_id'] == '0') {
                     </div>
                 </div>
                 <?php
-				if ($row['size'] == -1) { $checked0 = 'checked'; } else { $checked0 = ''; }
-                                if ($row['size'] == 1) { $checked1 = 'checked'; } else { $checked1 = ''; }
-                                if ($row['size'] == 2) { $checked2 = 'checked'; } else { $checked2 = ''; }
-                                if ($row['size'] == 3) { $checked3 = 'checked'; } else { $checked3 = ''; }
-                                if ($row['size'] == 4) { $checked4 = 'checked'; } else { $checked4 = ''; }
-				if ($row['size'] == 5) { $checked5 = 'checked'; } else { $checked5 = ''; }
+                                if (($row['size'] == -1 || $row['size'] == 1) && $row['max_size'] == '5') { $checked0 = 'checked'; } else { $checked0 = ''; }
+                                if ($row['size'] == 1 && $row['max_size'] == '1') { $checked1 = 'checked'; } else { $checked1 = ''; }
+                                if ($row['size'] == 2 && $row['max_size'] == '2') { $checked2 = 'checked'; } else { $checked2 = ''; }
+                                if ($row['size'] == 3 && $row['max_size'] == '3') { $checked3 = 'checked'; } else { $checked3 = ''; }
+                                if ($row['size'] == 4 && $row['max_size'] == '4') { $checked4 = 'checked'; } else { $checked4 = ''; }
+                                if ($row['size'] == 5 && $row['max_size'] == '5') { $checked5 = 'checked'; } else { $checked5 = ''; }
                 ?>
                 <label class="btn btn-secondary">
                     <input type="radio" name="size" id="size_-1" value="size_-1" <?php echo $checked0; ?>> <?php echo i8ln("All"); ?>

--- a/pages/display/pokemon.php
+++ b/pages/display/pokemon.php
@@ -479,18 +479,18 @@ while ($row = $result->fetch_assoc()) { $gen9 = $row['count']; }
                                                         </span>
                                                     </li>
                                                     <?php }
-                                                            if ($row['size'] <> '-1') {
+                                                            if ($row['size'] == $row['max_size']) {
                                                             ?>
                                                     <li
                                                         class="list-group-item d-flex justify-content-between align-items-center">
                                                         <?php echo i8ln("SIZE"); ?>
                                                         <span class="badge badge-primary badge-pill">
                                                             <?php
-                                                                    if ($row['size'] == '1') {  echo i8ln("XXS"); }
-                                                                    if ($row['size'] == '2') {  echo i8ln("XS"); }
-                                                                    if ($row['size'] == '3') {  echo i8ln("M"); }
-                                                                    if ($row['size'] == '4') {  echo i8ln("XL"); }
-                                                                    if ($row['size'] == '5') {  echo i8ln("XXL"); }
+                                                                    if ($row['size'] == '1' && $row['max_size'] == '1') {  echo i8ln("XXS"); }
+                                                                    if ($row['size'] == '2' && $row['max_size'] == '2') {  echo i8ln("XS"); }
+                                                                    if ($row['size'] == '3' && $row['max_size'] == '3') {  echo i8ln("M"); }
+                                                                    if ($row['size'] == '4' && $row['max_size'] == '4') {  echo i8ln("XL"); }
+                                                                    if ($row['size'] == '5' && $row['max_size'] == '5') {  echo i8ln("XXL"); }
                                                         ?>
                                                         </span>
                                                     </li>


### PR DESCRIPTION
I decided to "fix" an ugly issue with sizes I described here: https://discord.com/channels/358180805031493634/786241014037741609/1150152266012184659
My ugly fix is way better than current logic but since there's still no support for sizes ranges - it's not perfect.

Basically what I did is correctly display sizes on trackings preview:
- when someone tracks everything there's no more `XXS` label (no label to be more specific) - modal edit has `ALL` selected
- when someone tracks eg. `size:XXS-XXS` there's a correct `XXS` label - modal edit has `XXS` selected

Flaws:
- no ranges, obviously
- there's no label when someone uses ranges, eg `size:XL-XXL` but when user edits their tracking it shows in edit modal `ALL` selected so any updates would basically change that `size:XL-XXL` to min-max values (technically it's size=-1, max_size=5) - I had to do it that way cause otherwise there would be no size selected which would cause an error on each update

